### PR TITLE
use broccoli persistent filter between deploys

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -44,7 +44,14 @@ bower install
 
 # Skip dependency checking because it'll fail when devDependencies are missing (e.g. testing dependencies)
 echo "-----> Running Ember CLI Build"
-SKIP_DEPENDENCY_CHECKER=true ./node_modules/.bin/ember build --environment=production
+
+# Make build cache directory.
+# Unfortunately a "private" API:
+# https://github.com/stefanpenner/broccoli-persistent-filter/blob/f862807b9622195dcb042696900b927b9624fbf7/lib/strategies/persistent.js#L16
+CACHE_DIR=$2
+BROCCOLI_CACHE_DIR="${CACHE_DIR}/broccoli"
+mkdir -p BROCCOLI_CACHE_DIR
+BROCCOLI_PERSISTENT_FILTER_CACHE_ROOT=$BROCCOLI_CACHE_DIR SKIP_DEPENDENCY_CHECKER=true ./node_modules/.bin/ember build --environment=production
 
 echo "-----> Installing dependencies for CDN prepend rewriting"
 npm install replace


### PR DESCRIPTION
The Broccoli Persistent Filter cache should take us out of "cold boot"
(nothing has been compiled) into "warm boot" (process just started but
there are some things in the cache).

https://github.com/ember-cli/ember-cli/blob/master/PERF_GUIDE.md
