### PR TITLE
employ existing bower_components

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,18 @@ This buildpack injects a default [static.json](https://github.com/hone/heroku-bu
 
 ## Example Application
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://dashboard.heroku.com/new?template=https://github.com/heroku/heroku-static-ember)
+
+## Bower
+For optimal performance, add the following (or similar) to your project's `package.json`:
+```js
+"postinstall": "bower install"
+```
+
+and ensure `bower` is included your `package.json`'s `dependencies`:
+```js
+"dependencies": {
+  "bower": "*"
+}
+```
+
+This allows the nodejs buildpack to cache `bower_components`  yielding faster build times 🙌

--- a/bin/compile
+++ b/bin/compile
@@ -10,11 +10,6 @@ set -o nounset    # fail on unset variables
 BUILD_DIR=${1:-}
 ENV_DIR=${3:-}
 BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
-BOWER_BIN="./node_modules/.bin/bower"
-HAS_YARN_LOCK="false"
-if [ -f "$BUILD_DIR/yarn.lock" ]; then
-  HAS_YARN_LOCK="true"
-fi
 
 export_env_dir() {
   whitelist_regex=${2:-''}
@@ -48,18 +43,13 @@ else
   if [ -x $BOWER_BIN ]; then
     echo "-----> Using bower from package.json"
   else
-    if [ "$HAS_YARN_LOCK" == "true" ]; then
-      echo "-----> Installing Bower (via yarn)"
-      yarn add bower
-    else
-      echo "-----> Installing Bower (via npm)"
-      npm install bower
-    fi
+    echo "-----> Installing Bower"
+    npm install --ignore-scripts bower
   fi
 
   echo "-----> Installing dependencies defined in bower.json"
 
-  $BOWER_BIN install
+  bower install
   BOWER_EXIT_CODE=$?
 
   if [ $BOWER_EXIT_CODE -ne 0 ]
@@ -73,10 +63,5 @@ fi
 echo "-----> Running Ember CLI Build"
 SKIP_DEPENDENCY_CHECKER=true ./node_modules/.bin/ember build --environment=production
 
-if [ "$HAS_YARN_LOCK" == "true" ]; then
-  echo "-----> Installing dependencies for CDN prepend rewriting (via yarn)"
-  yarn add replace
-else
-  echo "-----> Installing dependencies for CDN prepend rewriting (via npm)"
-  npm install replace
-fi
+echo "-----> Installing dependencies for CDN prepend rewriting"
+npm install --ignore-scripts replace

--- a/bin/compile
+++ b/bin/compile
@@ -10,6 +10,11 @@ set -o nounset    # fail on unset variables
 BUILD_DIR=${1:-}
 ENV_DIR=${3:-}
 BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
+BOWER_BIN="./node_modules/.bin/bower"
+HAS_YARN_LOCK="false"
+if [ -f "$BUILD_DIR/yarn.lock" ]; then
+  HAS_YARN_LOCK="true"
+fi
 
 export_env_dir() {
   whitelist_regex=${2:-''}
@@ -35,16 +40,43 @@ cp -n $BP_DIR/scripts/Procfile $BUILD_DIR/Procfile
 echo "-----> Copying static.json to application slug"
 cp -n $BP_DIR/scripts/static.json $BUILD_DIR/static.json
 
-echo "-----> Installing Bower package manager"
 cd $BUILD_DIR
-npm install bower
 
-echo '-----> Installing Bower dependencies'
-bower install
+if [ -d "./bower_components" ]; then
+  echo "-----> Relying on cached bower_components"
+else
+  if [ -x $BOWER_BIN ]; then
+    echo "-----> Using bower from package.json"
+  else
+    if [ "$HAS_YARN_LOCK" == "true" ]; then
+      echo "-----> Installing Bower (via yarn)"
+      yarn add bower
+    else
+      echo "-----> Installing Bower (via npm)"
+      npm install bower
+    fi
+  fi
+
+  echo "-----> Installing dependencies defined in bower.json"
+
+  $BOWER_BIN install
+  BOWER_EXIT_CODE=$?
+
+  if [ $BOWER_EXIT_CODE -ne 0 ]
+  then
+    echo "-----> Bower installation failed, aborting Ember CLI Build"
+    exit $BOWER_EXIT_CODE
+  fi
+fi
 
 # Skip dependency checking because it'll fail when devDependencies are missing (e.g. testing dependencies)
 echo "-----> Running Ember CLI Build"
 SKIP_DEPENDENCY_CHECKER=true ./node_modules/.bin/ember build --environment=production
 
-echo "-----> Installing dependencies for CDN prepend rewriting"
-npm install replace
+if [ "$HAS_YARN_LOCK" == "true" ]; then
+  echo "-----> Installing dependencies for CDN prepend rewriting (via yarn)"
+  yarn add replace
+else
+  echo "-----> Installing dependencies for CDN prepend rewriting (via npm)"
+  npm install replace
+fi


### PR DESCRIPTION
tl;dr this should speed up builds of ember-cli applications that use yarn or cache bower_components

Installing bower dependencies in the buildpack rather than with the `postinstall` hook of of your `package.json` renders the nodejs buildpack's caching of `bower_components` inert. This fixes that.